### PR TITLE
Resolve idempotence issue which happens when a patch from the same source needs to be applied multiple times

### DIFF
--- a/manifests/opatch.pp
+++ b/manifests/opatch.pp
@@ -48,8 +48,6 @@ define oradb::opatch(
           ensure => present,
           source => "${mountPoint}/${patch_file}",
           mode   => '0775',
-          owner  => $user,
-          group  => $group,
         }
       }
     }


### PR DESCRIPTION
This can happen when an Oracle patch need to be applied
to both the database home and the grid home

@rmestrum Voor nu op jouw interne fork aangezien dit is waar ons platform momenteel nog gebruik van maakt

Voorkomt gedrag zoals onderstaand:
Run1:

```
Notice: /Stage[main]/Profile::Db::Auto_patches/Oradb::Opatch[p18139609_112040_grid]/File[/install/p18139609_112040_Linux-x86-64.zip]/owner: owner changed 'oracle' to 'grid'
Info: search for patchid 18031668
Info: opatch_status for patch 18139609 command: /opt/oracle/app/11.2.0.4/db_1/OPatch/opatch lsinventory -patch_id -oh /opt/oracle/app/11.2.0.4/db_1 -invPtrLoc /etc/oraInst.loc
Info: opatch_status output 18031668 for patchId 18031668
Info: search for patchid 18031668
Info: opatch_status for patch 18139609 command: /opt/grid/11.2.0.4/grid/OPatch/opatch lsinventory -patch_id -oh /opt/grid/11.2.0.4/grid -invPtrLoc /etc/oraInst.loc
Info: opatch_status output 18031668 for patchId 18031668
Info: Oradb::Opatch[p18139609_112040_grid]: Scheduling refresh of Sleep[auto_patch_sleep_until_restarted]
Info: Oradb::Opatch[p18139609_112040_grid]: Scheduling refresh of Ora_exec[@catbundle.sql psu apply]
Info: Oradb::Opatch[p18139609_112040_grid]: Scheduling refresh of Sleep[wait_for_mount_orabackup]
Notice: /Stage[main]/Profile::Db::Auto_patches/Sleep[wait_for_mount_orabackup]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Db::Catbundle/Ora_exec[@catbundle.sql psu apply]: Triggered 'refresh' from 1 events
```

Run 2:

```
Notice: /Stage[main]/Profile::Db::Hb/Profile::Db::Auto_patches/Oradb::Opatch[p18139609_112040_oracle]/File[/install/p18139609_112040_Linux-x86-64.zip]/owner: owner changed 'grid' to 'oracle'
Info: search for patchid 18031668
Info: opatch_status for patch 18139609 command: /opt/oracle/app/11.2.0.4/db_1/OPatch/opatch lsinventory -patch_id -oh /opt/oracle/app/11.2.0.4/db_1 -invPtrLoc /etc/oraInst.loc
Info: opatch_status output 18031668 for patchId 18031668
Info: Oradb::Opatch[p18139609_112040_oracle]: Scheduling refresh of Sleep[auto_patch_sleep_until_restarted]
Info: Oradb::Opatch[p18139609_112040_oracle]: Scheduling refresh of Sleep[wait_for_mount_orabackup]
Info: Oradb::Opatch[p18139609_112040_oracle]: Scheduling refresh of Ora_exec[@catbundle.sql psu apply]
Info: search for patchid 18031668
Info: opatch_status for patch 18139609 command: /opt/grid/11.2.0.4/grid/OPatch/opatch lsinventory -patch_id -oh /opt/grid/11.2.0.4/grid -invPtrLoc /etc/oraInst.loc
Info: opatch_status output 18031668 for patchId 18031668
Notice: /Stage[main]/Profile::Db::Hb/Profile::Db::Auto_patches/Sleep[wait_for_mount_orabackup]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Profile::Db::Hb/Profile::Db::Catbundle/Ora_exec[@catbundle.sql psu apply]: Triggered 'refresh' from 1 events
```

Nu met deze wijziging wordt de betreffende patch file maar 1 keer voorzien van de juiste permissies (root:root) en wordt de code (en daarmee ook de orabackup en catbundle handelingen) alleen uitgevoerd bij de allereerste puppet run in plaats van elke puppet run
